### PR TITLE
Fix incorrect rid

### DIFF
--- a/nuget/Avalonia.Angle.Windows.Natives.csproj
+++ b/nuget/Avalonia.Angle.Windows.Natives.csproj
@@ -10,12 +10,12 @@
 	<ItemGroup>
 		<Content Include="..\out\x64\av_libglesv2.dll">
 			<Pack>true</Pack>
-			<PackagePath>runtimes\win7-x64\native</PackagePath>
+			<PackagePath>runtimes\win-x64\native</PackagePath>
 		</Content>
 
 		<Content Include="..\out\x86\av_libglesv2.dll">
 			<Pack>true</Pack>
-			<PackagePath>runtimes\win7-x86\native</PackagePath>
+			<PackagePath>runtimes\win-x86\native</PackagePath>
 		</Content>
 
 		<Content Include="..\out\arm64\av_libglesv2.dll">


### PR DESCRIPTION
We should use `win-x64` and `win-x86` instead of the `win7` variants, otherwise the dll won't be copied on Windows without setting the explicit win7 rid.